### PR TITLE
Put badges below title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
+### qtools 
+
 [![Travis](https://api.travis-ci.org/mpurg/qtools.svg?branch=master)](https://travis-ci.org/mpurg/qtools)  [![Coverage Status](https://coveralls.io/repos/github/mpurg/qtools/badge.svg?branch=master)](https://coveralls.io/github/mpurg/qtools?branch=master)
-
-  
-  
-
-### README 
 
 #### Description
 


### PR DESCRIPTION
This is the way most repositories on GitHub are doing this, with an example being [Numpy](https://github.com/numpy/numpy). Just makes for a more consistent experience.