### PR TITLE
Update q_plot.py to specify location argument

### DIFF
--- a/qscripts-cli/q_plot.py
+++ b/qscripts-cli/q_plot.py
@@ -110,7 +110,7 @@ class PlotApp():
         for i, plotdata_file in enumerate(self.plotdata_files):
             handls.append(mpatches.Patch(color=self._COLORS[i]))
             labls.append("%d: %s" % (i, plotdata_file))
-        self.figure.legend(handls, labls, pos, prop=self.legend_font)
+        self.figure.legend(handls, labls, loc=pos, prop=self.legend_font)
 
 
     def change_geometry(self):


### PR DESCRIPTION
Presumably matplotlib has changed since this code was originally written, and I can't see a version of matplotlib that this is intended for. It all seems to work fine in recent versions, except it throws an error from providing too many positional arguments. Specifying the position variable is for the location fixes this, and allows changing between different graphs without closing and reopening the program.